### PR TITLE
Update python_version 3.13 phase 5

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+ignore=.venv

--- a/cisco_firepower.json
+++ b/cisco_firepower.json
@@ -13,7 +13,7 @@
     "product_name": "Cisco Firepower",
     "product_version_regex": ".*",
     "min_phantom_version": "6.2.2",
-    "python_version": "3",
+    "python_version": "3.9, 3.13",
     "logo": "logo_cisco.svg",
     "logo_dark": "logo_cisco_dark.svg",
     "fips_compliant": true,

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,2 +1,3 @@
 **Unreleased**
 * Update dependencies for Python 3.13
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13 for phase 5 part 2

[_Created by Sourcegraph batch change `grokas-splunk/python-versions-3.13-phase5-part2`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/python-versions-3.13-phase5-part2)