### PR TITLE
fix: remediate Cisco Firepower connector vulnerabilities

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.15.22
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: v1.40.7
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -43,12 +43,12 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.136.0
+    rev: v1.165.0
     hooks:
       - id: semgrep
         additional_dependencies: ["setuptools==81.0.0"]
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.1.7
     hooks:
       - id: build-docs
         language: python

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2016-2025 Splunk Inc.
+   Copyright (c) 2016-2026 Splunk Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Splunk SOAR App: Cisco Firepower
-Copyright (c) 2016-2025 Splunk Inc.
+Copyright (c) 2016-2026 Splunk Inc.
 Third Party Software Attributions:
 
 @@@@============================================================================

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cisco_firepower.json
+++ b/cisco_firepower.json
@@ -31,7 +31,7 @@
             "description": "Verify server certificate",
             "data_type": "boolean",
             "order": 1,
-            "default": false
+            "default": true
         },
         "username": {
             "description": "User with access to the Firepower node",

--- a/cisco_firepower.json
+++ b/cisco_firepower.json
@@ -5,7 +5,7 @@
     "publisher": "Splunk",
     "package_name": "phantom_cisco_firepower",
     "type": "firewall",
-    "license": "Copyright (c) 2016-2025 Splunk Inc.",
+    "license": "Copyright (c) 2016-2026 Splunk Inc.",
     "main_module": "cisco_firepower_connector.py",
     "app_version": "2.0.4",
     "utctime_updated": "2025-09-24T19:22:20.269992Z",

--- a/cisco_firepower_connector.py
+++ b/cisco_firepower_connector.py
@@ -1,6 +1,6 @@
 # File: cisco_firepower_connector.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cisco_firepower_connector.py
+++ b/cisco_firepower_connector.py
@@ -141,7 +141,7 @@ class FP_Connector(BaseConnector):
         offset = 0
         limit = 50
         params = {"limit": limit}
-        while True:
+        for _page_number in range(MAX_NETWORK_GROUP_PAGES):
             params["offset"] = offset
             ret_val, response = self._api_run("get", self.api_path, self, params=params)
             if phantom.is_fail(ret_val):
@@ -164,9 +164,12 @@ class FP_Connector(BaseConnector):
             if "paging" in response and "next" in response["paging"]:
                 offset += limit
             else:
-                break
+                return self.set_status(phantom.APP_ERROR, "Please provide a valid value in the 'Network Group Object' parameter")
 
-        return self.set_status(phantom.APP_ERROR, "Please provide a valid value in the 'Network Group Object' parameter")
+        return self.set_status(
+            phantom.APP_ERROR,
+            f"Network group object not found after scanning {MAX_NETWORK_GROUP_PAGES} pages; aborting the lookup",
+        )
 
     def _get_group_object_networks(self, action_result):
         """

--- a/cisco_firepower_connector.py
+++ b/cisco_firepower_connector.py
@@ -47,7 +47,7 @@ class FP_Connector(BaseConnector):
         self.domain_uuid = ""
         self.netgroup_uuid = ""
         self.headers = HEADERS
-        self.verify = False
+        self.verify = True
         self.nothing_to_deploy = False
         self.ip_version = None
         self.generate_new_token = False
@@ -93,7 +93,7 @@ class FP_Connector(BaseConnector):
         self.password = config["password"]
         self.domain_name = config["domain_name"].lower()
         self.network_group_object = config["network_group_object"]
-        self.verify = config.get("verify_server_cert", False)
+        self.verify = config.get("verify_server_cert", True)
 
         force = True if self.get_action_identifier() == "test_connectivity" else False
         ret_val = self._get_token(self, force=force)

--- a/cisco_firepower_connector.py
+++ b/cisco_firepower_connector.py
@@ -13,6 +13,8 @@
 # either express or implied. See the License for the specific language governing permissions
 # and limitations under the License.
 
+import time
+
 import encryption_helper
 import phantom.app as phantom
 import requests
@@ -385,8 +387,40 @@ class FP_Connector(BaseConnector):
         if phantom.is_fail(ret_val):
             return action_result.get_status()
 
-        self.network_group_list = response.get("literals", [])
-        return phantom.APP_SUCCESS
+        task_id = ((response.get("metadata") or {}).get("task") or {}).get("id")
+        if not task_id:
+            return action_result.set_status(phantom.APP_ERROR, "Deployment request returned no task ID; deployment outcome is unknown")
+
+        return self._poll_deployment_task(task_id, action_result)
+
+    def _poll_deployment_task(self, task_id, action_result):
+        """Wait for a Firepower deployment task to reach a terminal state."""
+        task_path = TASK_STATUS_ENDPOINT.format(self.domain_uuid, task_id)
+        deadline = time.monotonic() + DEPLOYMENT_POLL_TIMEOUT
+
+        while time.monotonic() < deadline:
+            ret_val, response = self._api_run("get", task_path, action_result)
+            if phantom.is_fail(ret_val):
+                return action_result.set_status(
+                    phantom.APP_ERROR,
+                    f"Failed to retrieve deployment task {task_id}: {action_result.get_message()}",
+                )
+
+            status = str(response.get("status", "")).upper()
+            if status == "DEPLOYED":
+                return phantom.APP_SUCCESS
+            if status in ("FAILED", "ABORTED"):
+                return action_result.set_status(
+                    phantom.APP_ERROR,
+                    f"Deployment task {task_id} ended with status {status}: {response.get('message', '')}",
+                )
+
+            time.sleep(DEPLOYMENT_POLL_INTERVAL)
+
+        return action_result.set_status(
+            phantom.APP_ERROR,
+            f"Timed out waiting for deployment task {task_id}; deployment outcome is unknown",
+        )
 
     def _handle_test_connectivity(self, param):
         """

--- a/cisco_firepower_connector.py
+++ b/cisco_firepower_connector.py
@@ -293,7 +293,7 @@ class FP_Connector(BaseConnector):
                 if phantom.is_fail(ret_val):
                     return action_result.get_status(), None
 
-                return self._api_run(method, resource, action_result, json_body, headers_only, first_try=False)
+                return self._api_run(method, resource, action_result, json_body, headers_only, first_try=False, params=params)
 
             message = "Error from server. Status Code: {} Data from server: {}".format(
                 result.status_code, result.text.replace("{", "{{").replace("}", "}}")
@@ -436,6 +436,30 @@ class FP_Connector(BaseConnector):
 
         return action_result.set_status(phantom.APP_SUCCESS)
 
+    def _update_group_literal(self, action_result, add):
+        """Atomically add or remove the destination literal from the network group."""
+        ret_val = self._get_group_object_networks(action_result)
+        if phantom.is_fail(ret_val):
+            return action_result.get_status(), False
+
+        already_in_desired_state = (self.destination_dict in self.network_group_list) == add
+        if already_in_desired_state:
+            return phantom.APP_SUCCESS, False
+
+        body = {
+            "id": self.netgroup_uuid,
+            "type": "NetworkGroup",
+            "literals": [self.destination_dict],
+        }
+        params = {"action": "add" if add else "remove"}
+        ret_val, response = self._api_run("put", self.api_path, action_result, body, params=params)
+        if phantom.is_fail(ret_val):
+            return action_result.get_status(), False
+
+        self.network_group_list = response.get("literals", self.network_group_list)
+        self.network_group_objects = response.get("objects", self.network_group_objects)
+        return phantom.APP_SUCCESS, True
+
     def _handle_block_ip(self, param):
         """
         This method blocks an IP/network.
@@ -446,11 +470,6 @@ class FP_Connector(BaseConnector):
         action_result = ActionResult(dict(param))
         self.add_action_result(action_result)
 
-        # Initializes the current networks and sets the URL
-        ret_val = self._get_group_object_networks(action_result)
-        if phantom.is_fail(ret_val):
-            return action_result.get_status()
-
         self.destination_network = param["ip"]
 
         if self._validate_ip():
@@ -458,21 +477,12 @@ class FP_Connector(BaseConnector):
         else:
             return action_result.set_status(phantom.APP_ERROR, f"Invalid IP: {self.destination_network}")
 
-        if self.destination_dict in self.network_group_list:
-            return action_result.set_status(phantom.APP_SUCCESS, f"{self.destination_network} is already present in the blocklist")
-
-        self.network_group_list.append(self.destination_dict)
-
-        body = {
-            "id": self.netgroup_uuid,
-            "name": self.network_group_object,
-            "literals": self.network_group_list,
-            "objects": self.network_group_objects,
-        }
-
-        ret_val, _ = self._api_run("put", self.api_path, action_result, body)
+        ret_val, changed = self._update_group_literal(action_result, add=True)
         if phantom.is_fail(ret_val):
             return action_result.get_status()
+
+        if not changed:
+            return action_result.set_status(phantom.APP_SUCCESS, f"{self.destination_network} is already present in the blocklist")
 
         ret_val = self._deploy_config(action_result)
         if phantom.is_fail(ret_val):
@@ -488,11 +498,6 @@ class FP_Connector(BaseConnector):
         action_result = ActionResult(dict(param))
         self.add_action_result(action_result)
 
-        # Initializes the current networks and sets the URL
-        ret_val = self._get_group_object_networks(action_result)
-        if phantom.is_fail(ret_val):
-            return action_result.get_status()
-
         self.destination_network = param["ip"]
 
         if self._validate_ip():
@@ -500,21 +505,12 @@ class FP_Connector(BaseConnector):
         else:
             return action_result.set_status(phantom.APP_ERROR, f"Invalid IP: {self.destination_network}")
 
-        if self.destination_dict not in self.network_group_list:
-            return action_result.set_status(phantom.APP_SUCCESS, f"{self.destination_network} is not present in the blocklist")
-
-        self.network_group_list.remove(self.destination_dict)
-
-        body = {
-            "id": self.netgroup_uuid,
-            "name": self.network_group_object,
-            "literals": self.network_group_list,
-            "objects": self.network_group_objects,
-        }
-
-        ret_val, _ = self._api_run("put", self.api_path, action_result, body)
+        ret_val, changed = self._update_group_literal(action_result, add=False)
         if phantom.is_fail(ret_val):
             return action_result.get_status()
+
+        if not changed:
+            return action_result.set_status(phantom.APP_SUCCESS, f"{self.destination_network} is not present in the blocklist")
 
         ret_val = self._deploy_config(action_result)
         if phantom.is_fail(ret_val):

--- a/cisco_firepower_connector.py
+++ b/cisco_firepower_connector.py
@@ -44,6 +44,7 @@ class FP_Connector(BaseConnector):
         self.token = ""
         self.api_path = ""
         self.network_group_list = []
+        self.network_group_objects = []
         self.domain_uuid = ""
         self.netgroup_uuid = ""
         self.headers = HEADERS
@@ -186,6 +187,7 @@ class FP_Connector(BaseConnector):
             return action_result.get_status()
 
         self.network_group_list = response.get("literals", [])
+        self.network_group_objects = response.get("objects", [])
         return phantom.APP_SUCCESS
 
     def _get_firepower_deployable_devices(self, action_result):
@@ -461,7 +463,12 @@ class FP_Connector(BaseConnector):
 
         self.network_group_list.append(self.destination_dict)
 
-        body = {"id": self.netgroup_uuid, "name": self.network_group_object, "literals": (self.network_group_list)}
+        body = {
+            "id": self.netgroup_uuid,
+            "name": self.network_group_object,
+            "literals": self.network_group_list,
+            "objects": self.network_group_objects,
+        }
 
         ret_val, _ = self._api_run("put", self.api_path, action_result, body)
         if phantom.is_fail(ret_val):
@@ -498,7 +505,12 @@ class FP_Connector(BaseConnector):
 
         self.network_group_list.remove(self.destination_dict)
 
-        body = {"id": self.netgroup_uuid, "name": self.network_group_object, "literals": (self.network_group_list)}
+        body = {
+            "id": self.netgroup_uuid,
+            "name": self.network_group_object,
+            "literals": self.network_group_list,
+            "objects": self.network_group_objects,
+        }
 
         ret_val, _ = self._api_run("put", self.api_path, action_result, body)
         if phantom.is_fail(ret_val):

--- a/cisco_firepower_connector.py
+++ b/cisco_firepower_connector.py
@@ -516,7 +516,13 @@ class FP_Connector(BaseConnector):
             return action_result.get_status()
 
         if not changed:
-            return action_result.set_status(phantom.APP_SUCCESS, f"{self.destination_network} is already present in the blocklist")
+            ret_val = self._deploy_config(action_result)
+            if phantom.is_fail(ret_val):
+                return action_result.get_status()
+            return action_result.set_status(
+                phantom.APP_SUCCESS,
+                f"{self.destination_network} is already present in the blocklist; pending configuration was deployed",
+            )
 
         ret_val = self._deploy_config(action_result)
         if phantom.is_fail(ret_val):
@@ -544,7 +550,13 @@ class FP_Connector(BaseConnector):
             return action_result.get_status()
 
         if not changed:
-            return action_result.set_status(phantom.APP_SUCCESS, f"{self.destination_network} is not present in the blocklist")
+            ret_val = self._deploy_config(action_result)
+            if phantom.is_fail(ret_val):
+                return action_result.get_status()
+            return action_result.set_status(
+                phantom.APP_SUCCESS,
+                f"{self.destination_network} is not present in the blocklist; pending configuration was deployed",
+            )
 
         ret_val = self._deploy_config(action_result)
         if phantom.is_fail(ret_val):

--- a/cisco_firepower_consts.py
+++ b/cisco_firepower_consts.py
@@ -1,6 +1,6 @@
 # File: cisco_firepower_consts.py
 #
-# Copyright (c) 2016-2025 Splunk Inc.
+# Copyright (c) 2016-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cisco_firepower_consts.py
+++ b/cisco_firepower_consts.py
@@ -27,3 +27,4 @@ DOMAIN_NAME_KEY = "domain_name"
 ENCRYPTION_ERR = "Error occurred while encrypting the state file"
 LIMIT = 100
 EXPANDED = "true"
+MAX_NETWORK_GROUP_PAGES = 2000

--- a/cisco_firepower_consts.py
+++ b/cisco_firepower_consts.py
@@ -15,6 +15,9 @@
 
 HOST_NETWORK_GROUPS_ENDPOINT = "/api/fmc_config/v1/domain/{0}/object/networkgroups/{1}"
 DEPLOYMENT_REQUESTS_ENDPOINT = "/api/fmc_config/v1/domain/{0}/deployment/deploymentrequests"
+TASK_STATUS_ENDPOINT = "/api/fmc_config/v1/domain/{0}/job/taskstatuses/{1}"
+DEPLOYMENT_POLL_INTERVAL = 6
+DEPLOYMENT_POLL_TIMEOUT = 600
 DEPLOYABLE_DEVICES_ENDPOINT = "/api/fmc_config/v1/domain/{0}/deployment/deployabledevices?limit={1}&expanded={2}"
 NETWORK_GROUPS_ENDPOINT = "/api/fmc_config/v1/domain/{0}/object/networkgroups"
 TOKEN_ENDPOINT = "/api/fmc_platform/v1/auth/generatetoken"

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * Enabled TLS certificate verification by default for Firepower API connections.
+* Limited network group discovery to 2,000 pages so an invalid FMC pagination stream cannot loop indefinitely.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -3,3 +3,4 @@
 * Enabled TLS certificate verification by default for Firepower API connections.
 * Limited network group discovery to 2,000 pages so an invalid FMC pagination stream cannot loop indefinitely.
 * Preserved referenced network objects when block and unblock actions replace the Firepower network group.
+* Used Firepower atomic group-member updates so concurrent containment actions no longer replace one another.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* - Updated development checks.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-* - Updated development checks.
+* Enabled TLS certificate verification by default for Firepower API connections.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -2,3 +2,4 @@
 
 * Enabled TLS certificate verification by default for Firepower API connections.
 * Limited network group discovery to 2,000 pages so an invalid FMC pagination stream cannot loop indefinitely.
+* Preserved referenced network objects when block and unblock actions replace the Firepower network group.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -5,3 +5,4 @@
 * Preserved referenced network objects when block and unblock actions replace the Firepower network group.
 * Used Firepower atomic group-member updates so concurrent containment actions no longer replace one another.
 * Waited for Firepower deployment tasks to report success and surfaced failed, aborted, missing, or timed-out outcomes.
+* Checked and deployed pending Firepower configuration even when a block or unblock request already matched the staged group.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -4,3 +4,4 @@
 * Limited network group discovery to 2,000 pages so an invalid FMC pagination stream cannot loop indefinitely.
 * Preserved referenced network objects when block and unblock actions replace the Firepower network group.
 * Used Firepower atomic group-member updates so concurrent containment actions no longer replace one another.
+* Waited for Firepower deployment tasks to report success and surfaced failed, aborted, missing, or timed-out outcomes.


### PR DESCRIPTION
## Summary

- verify FMC TLS certificates by default and bound network group discovery
- preserve referenced members and use atomic FMC group-member add/remove updates
- poll deployment tasks to a terminal outcome and deploy pending configuration on idempotent retries

## Tracking

- PAPP: [PAPP-37985](https://splunk.atlassian.net/browse/PAPP-37985)
- PSAAS: PSAAS-30756, PSAAS-31827, PSAAS-32134, PSAAS-32185, PSAAS-32356, PSAAS-32402, PSAAS-32448
- Provenance: VULN-93481 / FS-1565, VULN-94551 / FS-3073, VULN-94857 / FS-3380, VULN-94908 / FS-3431, VULN-95079 / FS-3602, VULN-95125 / FS-3648, VULN-95171 / FS-3694

PSAAS-31704 was excluded under the campaign read-only policy because the reported behavior retrieves remote configuration data only. It was not linked or transitioned.

## Patch deviations

- Replaced the proposed retrying whole-group PUT with the documented FMC `action=add` and `action=remove` operations, which avoid replacing concurrent member changes.
- Corrected the proposed deployment task URL from the platform API to the documented FMC configuration endpoint `/api/fmc_config/v1/domain/{domainUUID}/job/taskstatuses/{objectId}` and used the documented deployment states.

Cisco API references:

- https://developer.cisco.com/docs/cisco-security-cloud-control-firewall-manager/update-network-group/
- https://www.cisco.com/c/en/us/td/docs/security/firepower/710/api/REST/firepower_management_center_rest_api_quick_start_guide_71/Objects_In_The_REST_API.html

## Verification

- `pre-commit run --all-files`
- `python3 -m py_compile cisco_firepower_connector.py cisco_firepower_consts.py`
- `git diff --check origin/main..HEAD`
- all commits are signed and each distinct retained fix has one functional commit and one release-note entry

## Breaking changes

- FMC TLS certificates are verified by default.
- block and unblock actions wait for deployment completion and fail on failed, aborted, missing, or timed-out deployment tasks.

Written by Codex.
