### PR TITLE
fix!: scope Firepower deployment and unblock changes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.22
+    rev: v0.16.1
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.42.1
+    rev: v1.43.2
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.2.8
+    rev: v2.2.9
     hooks:
       - id: build-docs
         language: python

--- a/cisco_firepower_connector.py
+++ b/cisco_firepower_connector.py
@@ -526,6 +526,25 @@ class FP_Connector(BaseConnector):
         self.network_group_objects = response.get("objects", self.network_group_objects)
         return phantom.APP_SUCCESS, True
 
+    def _get_owned_blocks(self, action_result):
+        """Return block values recorded for this asset and SOAR installation."""
+        try:
+            installation_id = self.get_product_installation_id()
+        except Exception as e:
+            return action_result.set_status(phantom.APP_ERROR, f"Unable to identify this SOAR installation: {e!s}"), None
+
+        if not installation_id:
+            return action_result.set_status(phantom.APP_ERROR, "Unable to identify this SOAR installation"), None
+
+        ownership = self._state.get(OWNED_BLOCKS_KEY)
+        if not isinstance(ownership, dict) or ownership.get("installation_id") != installation_id:
+            ownership = {"installation_id": installation_id, "values": []}
+            self._state[OWNED_BLOCKS_KEY] = ownership
+        elif not isinstance(ownership.get("values"), list):
+            ownership["values"] = []
+
+        return phantom.APP_SUCCESS, ownership["values"]
+
     def _handle_block_ip(self, param):
         """
         This method blocks an IP/network.
@@ -543,9 +562,16 @@ class FP_Connector(BaseConnector):
         else:
             return action_result.set_status(phantom.APP_ERROR, f"Invalid IP: {self.destination_network}")
 
+        ret_val, owned_blocks = self._get_owned_blocks(action_result)
+        if phantom.is_fail(ret_val):
+            return action_result.get_status()
+
         ret_val, changed = self._update_group_literal(action_result, add=True)
         if phantom.is_fail(ret_val):
             return action_result.get_status()
+
+        if changed and self.destination_dict["value"] not in owned_blocks:
+            owned_blocks.append(self.destination_dict["value"])
 
         if not changed:
             ret_val = self._deploy_config(action_result)
@@ -577,9 +603,21 @@ class FP_Connector(BaseConnector):
         else:
             return action_result.set_status(phantom.APP_ERROR, f"Invalid IP: {self.destination_network}")
 
+        ret_val, owned_blocks = self._get_owned_blocks(action_result)
+        if phantom.is_fail(ret_val):
+            return action_result.get_status()
+
+        if self.destination_dict["value"] not in owned_blocks:
+            return action_result.set_status(
+                phantom.APP_ERROR,
+                f"Refusing to unblock {self.destination_network}: the entry was not created by this asset on this SOAR installation",
+            )
+
         ret_val, changed = self._update_group_literal(action_result, add=False)
         if phantom.is_fail(ret_val):
             return action_result.get_status()
+
+        owned_blocks.remove(self.destination_dict["value"])
 
         if not changed:
             ret_val = self._deploy_config(action_result)

--- a/cisco_firepower_connector.py
+++ b/cisco_firepower_connector.py
@@ -198,6 +198,8 @@ class FP_Connector(BaseConnector):
         adds them to the firepower_deployable_devices variable.
         """
         # Get the current list of devices in the domain
+        self.firepower_deployable_devices = []
+        self.nothing_to_deploy = False
         self.api_path = DEPLOYABLE_DEVICES_ENDPOINT.format(self.domain_uuid, LIMIT, EXPANDED)
         self.debug_print(f"api_path: {self.api_path}")
 
@@ -218,6 +220,27 @@ class FP_Connector(BaseConnector):
             return action_result.set_status(phantom.APP_ERROR, message)
 
         return phantom.APP_SUCCESS
+
+    def _device_has_network_group_change(self, device_id, action_result):
+        """Return whether a device has a pending change for the configured network group."""
+        api_path = PENDING_CHANGES_ENDPOINT.format(self.domain_uuid, device_id)
+        params = {"expanded": EXPANDED, "filter": f"EntityUUID:{self.netgroup_uuid}"}
+        ret_val, response = self._api_run("get", api_path, action_result, params=params)
+        if phantom.is_fail(ret_val):
+            return (
+                action_result.set_status(
+                    phantom.APP_ERROR,
+                    f"Unable to verify pending changes for device {device_id}: {action_result.get_message()}",
+                ),
+                False,
+            )
+
+        items = response.get("items")
+        if not isinstance(items, list):
+            return action_result.set_status(phantom.APP_ERROR, f"Received invalid pending changes for device {device_id}"), False
+
+        network_group_id = self.netgroup_uuid.casefold()
+        return phantom.APP_SUCCESS, any(str(item.get("entityUUID", "")).casefold() == network_group_id for item in items)
 
     def _update_state(self):
         """
@@ -368,7 +391,17 @@ class FP_Connector(BaseConnector):
             self.debug_print("Nothing to deploy")
             return phantom.APP_SUCCESS
 
-        deployable_device_UUIDs = [device["id"] for device in self.firepower_deployable_devices]
+        deployable_device_UUIDs = []
+        for device in self.firepower_deployable_devices:
+            ret_val, has_network_group_change = self._device_has_network_group_change(device["id"], action_result)
+            if phantom.is_fail(ret_val):
+                return action_result.get_status()
+            if has_network_group_change:
+                deployable_device_UUIDs.append(device["id"])
+
+        if not deployable_device_UUIDs:
+            self.debug_print("No deployable device has a pending change for the configured network group")
+            return phantom.APP_SUCCESS
 
         self.api_path = DEPLOYMENT_REQUESTS_ENDPOINT.format(self.domain_uuid)
         self.debug_print(f"api_path: {self.api_path}")
@@ -376,8 +409,8 @@ class FP_Connector(BaseConnector):
         body = {
             "type": "DeploymentRequest",
             "version": "0",
-            "forceDeploy": True,
-            "ignoreWarning": True,
+            "forceDeploy": False,
+            "ignoreWarning": False,
             "deviceList": (deployable_device_UUIDs),
         }
 

--- a/cisco_firepower_consts.py
+++ b/cisco_firepower_consts.py
@@ -19,6 +19,7 @@ TASK_STATUS_ENDPOINT = "/api/fmc_config/v1/domain/{0}/job/taskstatuses/{1}"
 DEPLOYMENT_POLL_INTERVAL = 6
 DEPLOYMENT_POLL_TIMEOUT = 600
 DEPLOYABLE_DEVICES_ENDPOINT = "/api/fmc_config/v1/domain/{0}/deployment/deployabledevices?limit={1}&expanded={2}"
+PENDING_CHANGES_ENDPOINT = "/api/fmc_config/v1/domain/{0}/deployment/deployabledevices/{1}/pendingchanges"
 NETWORK_GROUPS_ENDPOINT = "/api/fmc_config/v1/domain/{0}/object/networkgroups"
 TOKEN_ENDPOINT = "/api/fmc_platform/v1/auth/generatetoken"
 HEADERS = {"Accept": "application/json"}

--- a/cisco_firepower_consts.py
+++ b/cisco_firepower_consts.py
@@ -28,6 +28,7 @@ DEFAULT_REQUEST_TIMEOUT = 30  # in seconds
 TOKEN_KEY = "X-auth-access-token"
 DOMAIN_UUID_KEY = "domain_uuid"
 DOMAIN_NAME_KEY = "domain_name"
+OWNED_BLOCKS_KEY = "owned_blocks"
 ENCRYPTION_ERR = "Error occurred while encrypting the state file"
 LIMIT = 100
 EXPANDED = "true"

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,2 +1,3 @@
 **Unreleased**
 * Scoped automatic deployments to devices with pending changes for the configured network group without forcing deployment or ignoring warnings.
+* Limited unblock actions to entries recorded as created by the same asset and SOAR installation.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Scoped automatic deployments to devices with pending changes for the configured network group without forcing deployment or ignoring warnings.


### PR DESCRIPTION
### Bug Fixes

- PSAAS-33456: limit automatic FMC deployment to devices whose pending changes include the configured network group, fail closed when device scope cannot be verified, and stop forcing deployments or suppressing warnings.
- PSAAS-34295: record successful block additions for the asset and SOAR installation, then refuse unblock requests for entries without matching local provenance.
- PSAAS-34253: confirmed the reported 401 retry defect is already fixed on `main` by commit `454781b` in merged PR #29, which preserves query parameters across token refresh; no duplicate code or release-note change was added.

### Manual Documentation

- [x] I have verified that manual documentation has been updated where appropriate. No manual documentation source change is needed because the app adds no action, parameter, authentication method, REST handler, or deployment-type restriction.

### Other information

#### Tracking

- PAPP: PAPP-38308 under ESPM-5228.
- PSAAS: PSAAS-33456, PSAAS-34253, PSAAS-34295.
- Provenance: VULN-98339 / FS-6174, VULN-101777 / FS-7761, VULN-101819 / FS-7803.
- PSAAS-34411 is platform-classified and is not included in this connector remediation.

#### Sources

- Cisco pending changes API and response model: https://developer.cisco.com/docs/cisco-security-cloud-control-firewall-manager/get-pending-changes/
- Cisco deployment request API: https://developer.cisco.com/docs/cisco-security-cloud-control-firewall-manager/create-deployment-request/
- Cisco network group update API: https://developer.cisco.com/docs/cisco-security-cloud-control-firewall-manager/update-network-group/
- Splunk SOAR product installation ID API: https://help.splunk.com/splunk-soar/soar-on-premises/develop-apps/6.4.0/app-structure/app-authoring-api

#### Cached patch review

- PSAAS-33456: rejected the suggested fail-open pending-change lookup and its unsupported response shape; this implementation uses Cisco's documented `EntityUUID` field and fails closed on lookup errors.
- PSAAS-34253: accepted the patch intent, but the exact `params=params` retry fix is already present in merged commit `454781b`.
- PSAAS-34295: retained SOAR-side provenance, but updates state through the connector's existing finalization lifecycle and changes ownership only after the corresponding FMC group update succeeds.

#### Verification

- `pre-commit run --all-files` passed, including Docker app packaging, SOAR App Linter, Semgrep, static tests, docs, notice, and release-note validation.
- `python3 -m py_compile cisco_firepower_connector.py cisco_firepower_consts.py` passed.
- `git diff --check origin/main..HEAD` passed.
- All three commits are signed and contain Codex attribution.
- Integration tests are deferred under the connector campaign policy.

#### Breaking changes

- Automatic deployment now skips devices without a matching network-group pending change, fails when scope cannot be verified, and no longer ignores FMC deployment warnings.
- `unblock ip` rejects pre-existing or externally created entries that lack ownership recorded by this asset on this SOAR installation.

Merge strategy: merge commit only; do not squash

Written by Codex.

---
Please refer to our [Contribution Guide](https://github.com/splunk-soar-connectors/.github/blob/main/.github/CONTRIBUTING.md) for any questions on submitting a pull request.

Thanks for contributing!
